### PR TITLE
Perceptor stage 2 fixes

### DIFF
--- a/Test/Live/IRD/realsense.cc
+++ b/Test/Live/IRD/realsense.cc
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
         cv::Mat covMat = SLAM.GetCurrentCovarianceMatrix(fx, fy, cameraPose, true);
 
         // Get the map points at the current VSLAM step
-        Eigen::MatrixXf map = SLAM.getMap();
+        Eigen::MatrixXf map = SLAM.GetMap();
         cout << "points: " << map.cols() << " (" << map.rows() << " coordinates each)" << endl;
         cout << "****************************************************************" << endl;
 

--- a/Test/Live/IRD/realsense.cc
+++ b/Test/Live/IRD/realsense.cc
@@ -13,6 +13,7 @@
 #include <opencv2/opencv.hpp>
 #include <System.h>
 #include <sys/stat.h>
+#include <Eigen/Dense>
 
 #include "realsense.h"
 
@@ -124,10 +125,8 @@ int main(int argc, char **argv)
         cv::Mat covMat = SLAM.GetCurrentCovarianceMatrix(fx, fy, cameraPose, true);
 
         // Get the map points at the current VSLAM step
-        vector<ORB_SLAM2::MapPoint*> mapPoints = SLAM.getMap();
-        for (auto point: mapPoints){
-          cout << point->GetWorldPos() << endl;
-        }
+        Eigen::MatrixXf map = SLAM.getMap();
+        cout << "points: " << map.cols() << " (" << map.rows() << " coordinates each)" << endl;
         cout << "****************************************************************" << endl;
 
         if (printTraj && !cameraPose.empty())

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -76,11 +76,15 @@ public:
   bool isFinishedGBA(){
       unique_lock<std::mutex> lock(mMutexGBA);
       return mbFinishedGBA;
-  }   
+  }
 
   void RequestFinish();
 
   bool isFinished();
+
+  long unsigned int GetLoopCount() {
+    return loopCnt;
+  }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -142,6 +146,8 @@ protected:
   g2o::Sim3 mg2oScw;
 
   long unsigned int mLastLoopKFid;
+
+  long unsigned int loopCnt;
 
   // Variables related to Global Bundle Adjustment
   bool mbRunningGBA;

--- a/include/System.h
+++ b/include/System.h
@@ -22,9 +22,10 @@
 #ifndef SYSTEM_H
 #define SYSTEM_H
 
-#include<string>
-#include<thread>
-#include<opencv2/core/core.hpp>
+#include <string>
+#include <thread>
+#include <opencv2/core/core.hpp>
+#include <Eigen/Dense>
 
 #include "Tracking.h"
 #include "FrameDrawer.h"
@@ -143,7 +144,8 @@ public:
 
     cv::Mat GetCurrentCovarianceMatrix(float, float, cv::Mat, bool);
 
-    vector<MapPoint*> getMap();
+    // Returns the currently stored map: each column is a 3D-point coordinates vector
+    Eigen::MatrixXf getMap();
 
 private:
     // Save/Load functions

--- a/include/System.h
+++ b/include/System.h
@@ -145,7 +145,7 @@ public:
     cv::Mat GetCurrentCovarianceMatrix(float, float, cv::Mat, bool);
 
     // Returns the currently stored map: each column is a 3D-point coordinates vector
-    Eigen::MatrixXf getMap();
+    Eigen::MatrixXf GetMap();
 
 private:
     // Save/Load functions

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -36,7 +36,7 @@ namespace ORB_SLAM2
 {
 LoopClosing::LoopClosing(Map *pMap, KeyFrameDatabase *pDB, fbow::Vocabulary *pFbowVoc, const bool bFixScale, const string &strSettingPath):
     mbResetRequested(false), mbFinishRequested(false), mbFinished(true), mpMap(pMap),
-    mpKeyFrameDB(pDB), mpFBOWVocabulary(pFbowVoc), mpMatchedKF(NULL), mLastLoopKFid(0), mbRunningGBA(false), mbFinishedGBA(true),
+    mpKeyFrameDB(pDB), mpFBOWVocabulary(pFbowVoc), mpMatchedKF(NULL), mLastLoopKFid(0), loopCnt(0), mbRunningGBA(false), mbFinishedGBA(true),
     mbStopGBA(false), mpThreadGBA(NULL), mbFixScale(bFixScale), mnFullBAIdx(0)
 {
   cv::FileStorage fSettings(strSettingPath, cv::FileStorage::READ);
@@ -435,7 +435,8 @@ bool LoopClosing::ComputeSim3()
 
 void LoopClosing::CorrectLoop()
 {
-    cout << "Loop detected!" << endl;
+    loopCnt++;
+    cout << "Loop " << loopCnt << " detected!" << endl;
 
     // Send a stop signal to Local Mapping
     // Avoid new keyframes are inserted while correcting the loop
@@ -670,6 +671,7 @@ void LoopClosing::ResetIfRequested()
         mlpLoopKeyFrameQueue.clear();
         mLastLoopKFid=0;
         mbResetRequested=false;
+        loopCnt = 0;
     }
 }
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -26,6 +26,7 @@
 #include <pangolin/pangolin.h>
 #include <iomanip>
 #include <algorithm>
+#include <chrono>
 
 namespace ORB_SLAM2
 {
@@ -384,8 +385,15 @@ bool System::MapChanged()
 
 void System::Reset()
 {
+  // Wait for a Global Bundle Adjustment to finish
+  while (mpLoopCloser->isRunningGBA()) {
+    this_thread::sleep_for(chrono::milliseconds(500));
+  }
+
+  {
     unique_lock<mutex> lock(mMutexReset);
     mbReset = true;
+  }
 }
 
 void System::Shutdown()

--- a/src/System.cc
+++ b/src/System.cc
@@ -771,7 +771,7 @@ cv::Mat System::GetCurrentCovarianceMatrix(float fx, float fy, cv::Mat cameraPos
 }
 
 // Returns the currently stored map: each column is a 3D-point coordinates vector
-Eigen::MatrixXf System::getMap()
+Eigen::MatrixXf System::GetMap()
 {
   // Other threads must not update the map while this reads it
   unique_lock<mutex> mapLock(mpMap->mMutexMapUpdate);

--- a/src/System.cc
+++ b/src/System.cc
@@ -25,6 +25,7 @@
 #include <thread>
 #include <pangolin/pangolin.h>
 #include <iomanip>
+#include <algorithm>
 
 namespace ORB_SLAM2
 {
@@ -769,15 +770,34 @@ cv::Mat System::GetCurrentCovarianceMatrix(float fx, float fy, cv::Mat cameraPos
   }
 }
 
-vector<MapPoint*> System::getMap()
+// Returns the currently stored map: each column is a 3D-point coordinates vector
+Eigen::MatrixXf System::getMap()
 {
-  vector<MapPoint*> mapPoints;
-  vector<MapPoint*> _mapPoints = this->mpMap->GetAllMapPoints();
-  for (auto point: _mapPoints){
-    if (!point->isBad())
-      mapPoints.push_back(point);
+  // Other threads must not update the map while this reads it
+  unique_lock<mutex> mapLock(mpMap->mMutexMapUpdate);
+
+  // Get all valid map points
+  vector<MapPoint *> mapPoints = mpMap->GetAllMapPoints();
+  mapPoints.erase(
+    remove_if(
+      mapPoints.begin(),
+      mapPoints.end(),
+      [] (MapPoint * p) { return p->isBad(); }),
+      mapPoints.end());
+  
+  // Fill a matrix with their coordinates ([X Y Z]w = [Z -X -Y]o)
+  Eigen::MatrixXf pointsMat(3, mapPoints.size());
+  unsigned int col = 0;
+  for (auto p : mapPoints) {
+    cv::Mat pPos = p->GetWorldPos();
+    pointsMat.col(col) = Eigen::Vector3f(
+      pPos.at<float>(2),
+      -pPos.at<float>(0),
+      -pPos.at<float>(1));
+    col++;
   }
-  return mapPoints;
+
+  return pointsMat;
 }
 
 void System::SaveMap(const string &filename)


### PR DESCRIPTION
**Fixes:**

- System::GetMap acquires the Map::mMutexMapUpdate mutex before reading the points, in order to avoid data races with other threads (i.e. LoopClosing, Local Mapping, BAs) that could lead to access deleted objects.
- System::Reset waits for the LoopClosing to finish a Global BA before starting the reset procedure, avoiding segfaults; this has been tested successfully while closing a large global loop by covering the camera while the GBA was running: as expected, the reset took place only after the GBA was completed.

**New features:**

- GetMap returns an Eigen::MatrixXf where each column stores the world coordinates of a point in the current map.
- The LoopClosing objects stores and updates a loops counter, printed in the logs when a loop is detected.